### PR TITLE
Fix version being removed when part of date

### DIFF
--- a/src/main/java/net/covers1624/projectbot/checker/ProjectListChecker.java
+++ b/src/main/java/net/covers1624/projectbot/checker/ProjectListChecker.java
@@ -99,7 +99,7 @@ public class ProjectListChecker {
         for (Element li : ul.select("li")) {
             Element a = li.child(0);
             String version = a.text();
-            String desc = li.text().replace(version, "").trim();
+            String desc = li.text().replaceFirst(version, "").trim();
             desc = StringUtils.removeStart(desc, "(");
             desc = StringUtils.removeEnd(desc, ")");
             versions.put(version, new ProjectVersion(version, desc));


### PR DESCRIPTION
This PR fixes a current issue where if part of the date contains the version (for example, version 16 for 2021/03/16), then that part of the date would be mangled by the `replace` call which removes *all* matches (so the date becomes "2021/03/").

Switching to `replaceFirst` means it only removes the first match (the version itself), leaving the date intact.